### PR TITLE
Issue #15: $NODE_EXE not escaped in deploy.sh:119

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -116,7 +116,7 @@ fi
 # -----
 
 echo -n "Using Node "
-eval $NODE_EXE -v
+eval \"$NODE_EXE\" -v
 
 echo -n "Using npm "
 eval $NPM_CMD -v


### PR DESCRIPTION
Fix for Issue #15 where $NODE_EXE was being called without being escaped, causing an error to be printed to the console when the path contains a space.
